### PR TITLE
Use the MIT License also in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
               'auto-code-complete'],
     classifiers=['Development Status :: 4 - Beta',
                  'Intended Audience :: Developers',
-                 'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
+                 'License :: OSI Approved :: MIT License',
                  'Programming Language :: Python :: 3.7',
                  'Topic :: Software Development :: Libraries :: Python Modules'],
 )


### PR DESCRIPTION
Since the newer `pyproject.toml` and `LICENSE.txt`agree on MIT, use the MIT license in setup.py as well.