### PR TITLE
test_prodict.py: Fix mypy warning for Optional string (see #8)

### DIFF
--- a/prodict/__init__.py
+++ b/prodict/__init__.py
@@ -1,7 +1,5 @@
-from typing import Any, List, TypeVar, Tuple, get_type_hints
+from typing import Any, List
 import copy
-
-# from typing_inspect import get_parameters
 
 DICT_RESERVED_KEYS = vars(dict).keys()
 
@@ -21,9 +19,7 @@ def _dict_value(v, is_recursive, exclude_none, exclude_none_in_lists):
 
 
 def _none_condition(v, is_recursive, exclude_none):
-    if not exclude_none:
-        return True
-    return False if v is None else True
+    return v is not None if exclude_none else True
 
 
 # noinspection PyMethodParameters
@@ -62,30 +58,19 @@ class Prodict(dict):
     def __setstate__(self, state):
         return Prodict.from_dict(state)
 
-    # def __getnewargs__(self):
-    #     return tuple([None, None])
-    #
-    # def __getnewargs_ex__(self):
-    #     return tuple([None, None])
-
     def __deepcopy__(self, memo=None):
-        # print("__deepcopy__ type(self):", type(self))
         new = self.from_dict({})
         for key in self.keys():
             new.set_attribute(key, copy.deepcopy(self[key], memo=memo))
         return new
-        # return copy.deepcopy(self.from_dict(self.to_dict()), memo=memo)
 
     @classmethod
     def from_dict(cls, d: dict):
-        val: cls = cls(**d)
-        return val  # type: cls
+        return cls(**d)
 
     @classmethod
     def attr_has_default_value(cls, attr_name: str) -> bool:
-        if hasattr(cls, attr_name):
-            return True
-        return False
+        return bool(hasattr(cls, attr_name))
 
     @classmethod
     def get_attr_default_value(cls, attr_name: str):
@@ -101,9 +86,6 @@ class Prodict(dict):
     @classmethod
     def attr_types(cls):
         return cls.__annotations__ if hasattr(cls, '__annotations__') else {}
-        # if hasattr(cls, '__annotations__'):
-        #     return cls.__annotations__
-        # return {}
 
     @classmethod
     def attr_names(cls) -> List[str]:
@@ -141,10 +123,6 @@ class Prodict(dict):
         attr_type1 = self.attr_type(attr_name)
         constructor = None
         element_type = None
-        # print('     attr_name="{}" attr_type={} value={}'.format(attr_name, attr_type1, value))
-        # print("attr_type1:", attr_type1)
-        # print("type(attr_type1):", type(attr_type1))
-        # print(dir(attr_type1))
         if attr_type1 == float:
             constructor = float
         elif attr_type1 == str:
@@ -163,7 +141,6 @@ class Prodict(dict):
             elif issubclass(attr_type1, Prodict):
                 constructor = self.attr_type(attr_name).from_dict
         elif attr_type1 is List:
-            # if the type is 'List'
             constructor = list
         elif hasattr(attr_type1, '__origin__'):
             if attr_type1.__dict__['__origin__'] is list:
@@ -220,33 +197,6 @@ class Prodict(dict):
             else:
                 self.update({attr_name: value})
 
-    # def set_attribute(self, attr_name, value):
-    #     if self.has_attr(attr_name):
-    #         if value is None:
-    #             self.update({attr_name: None})
-    #         elif self.attr_type(attr_name) == Any:
-    #             self[attr_name] = value
-    #         elif isinstance(value, Prodict):
-    #             constructor = self.attr_type(attr_name)
-    #             self.update({attr_name: constructor.from_dict(value.to_dict())})
-    #         elif isinstance(value, dict):
-    #             constructor = self.attr_type(attr_name)
-    #             if constructor == dict:
-    #                 self.update({attr_name: Prodict.from_dict(value)})
-    #             # elif constructor == List:
-    #             #     if len(constructor.__args__) != 1:
-    #             #         raise TypeError('Only one dimensional List is supported')
-    #             #     constructor = constructor.__args__[0]
-    #             #     value  # type: List[constructor]
-    #             #     final_list: List[constructor] = []
-    #             #     for elem in value:
-    #             else:
-    #                 self.update({attr_name: constructor.from_dict(value)})
-    #         else:
-    #             self.update({attr_name: self.attr_type(attr_name)(value)})
-    #     else:
-    #         self[attr_name] = value
-
     def set_attributes(self_d921dfa9_4e93_4123_893d_a7e7eb783a32, **d):
         for k, v in d.items():
             self_d921dfa9_4e93_4123_893d_a7e7eb783a32.set_attribute(k, v)
@@ -255,57 +205,15 @@ class Prodict(dict):
         """
 
     def __getattr__(self, item):
-        # print('__getattr__("{}")'.format(item))
         return self[item]
-
-    # def __getattribute__(self, item):
-    #     print('__getattribute__("{}")'.format(item))
-    #     if item == '__annotations__':
-    #         return self.__annotations__
-    #     return self.__getattr__(item)
 
     def __setattr__(self, name: str, value) -> None:
         self.set_attribute(name, value)
 
     def to_dict(self, *args, is_recursive=False, exclude_none=False, exclude_none_in_lists=False, **kwargs):
-        # def get_value(v):
-        #     if isinstance(v, List):
-        #
-        #     if is_recursive:
-        #
-        # def list_without_none(a_list: List):
-        #     return [elem for elem in a_list if elem is not None]
-
-        # ret = {k: v.to_dict(is_recursive=is_recursive, exclude_none=exclude_none) if isinstance(v, Prodict) else v
-        #        for k, v in self.items()
-        #        if v or not exclude_none}
-
-        # if not is_recursive and not exclude_none:
-        #     ret = {k: v for k, v in self.items()}
-        # elif is_recursive and not exclude_none:
-        #     ret = {k: v.to_dict(is_recursive=is_recursive, exclude_none=exclude_none) if isinstance(v, Prodict) else v
-        #            for k, v in self.items()}
-        # elif not is_recursive and exclude_none:
-        #     ret = {k: v for k, v in self.items() if v is not None}
-        # else:
-        #     ret = {k: v.to_dict(is_recursive=is_recursive, exclude_none=exclude_none) if isinstance(v, Prodict) else v
-        #            for k, v in self.items() if v}
-
         ret = {k: _dict_value(v, is_recursive=is_recursive,
                               exclude_none=exclude_none,
                               exclude_none_in_lists=exclude_none_in_lists)
                for k, v in self.items()
                if _none_condition(v, is_recursive=is_recursive, exclude_none=exclude_none)}
-
-        # another way to do it
-        # ret2 = {}
-        # for k, v in self.items():
-        #     # print(k, v)
-        #     if exclude_none and v is None:
-        #         continue
-        #     if is_recursive and isinstance(v, Prodict):
-        #         vv = v.to_dict()
-        #     else:
-        #         vv = v
-        #     ret2[k] = vv
         return ret

--- a/prodict/__init__.py
+++ b/prodict/__init__.py
@@ -41,7 +41,8 @@ class Prodict(dict):  # type: ignore
 
     def __init__(
         self_d921dfa9_4e93_4123_893d_a7e7eb783a32,  # noqa
-        *args: Any, **kwargs: Any
+        *args: Any,
+        **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
 
@@ -195,8 +196,7 @@ class Prodict(dict):  # type: ignore
                     else:
                         element_constructor = element_type
 
-                    for v in value_list:
-                        new_list.append(element_constructor(v))
+                    new_list.extend(element_constructor(v) for v in value_list)
                     self.update({attr_name: new_list})
                 elif constructor == list:
                     self.update({attr_name: list(value)})
@@ -232,7 +232,7 @@ class Prodict(dict):  # type: ignore
         exclude_none_in_lists: bool = False,
         **kwargs: Any,
     ) -> Dict[Any, Any]:
-        ret = {
+        return {
             k: _dict_value(
                 v,
                 is_recursive=is_recursive,
@@ -240,8 +240,5 @@ class Prodict(dict):  # type: ignore
                 exclude_none_in_lists=exclude_none_in_lists,
             )
             for k, v in self.items()
-            if _none_condition(
-                v, exclude_none=exclude_none
-            )
+            if _none_condition(v, exclude_none=exclude_none)
         }
-        return ret

--- a/prodict/__init__.py
+++ b/prodict/__init__.py
@@ -1,3 +1,5 @@
+# Global comments:
+# self is avoided to fix #15
 from typing import Any, List
 import copy
 
@@ -13,8 +15,11 @@ def _dict_value(v, is_recursive, exclude_none, exclude_none_in_lists):
         return v.to_dict(is_recursive=is_recursive, exclude_none=exclude_none)
     if exclude_none_in_lists and isinstance(v, List):
         return [
-            item.to_dict(exclude_none=True, is_recursive=is_recursive) if isinstance(item, Prodict) else item
-            for item in v]
+            item.to_dict(exclude_none=True, is_recursive=is_recursive)
+            if isinstance(item, Prodict)
+            else item
+            for item in v
+        ]
     return v
 
 
@@ -25,24 +30,21 @@ def _none_condition(v, is_recursive, exclude_none):
 # noinspection PyMethodParameters
 class Prodict(dict):
     """
-    Prodict = Dictionary with IDE friendly(auto code completion), dot-accessible attributes and more.
+    Prodict = Dictionary with IDE friendly(auto code completion),
+    dot-accessible attributes and more.
     """
 
     def __init__(self_d921dfa9_4e93_4123_893d_a7e7eb783a32, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        """
-        'self' parameter name is changed because of #15: https://github.com/ramazanpolat/prodict/issues/15 
-        """
-
-        # Set all properties to None (https://github.com/ramazanpolat/prodict/issues/3)
-        for k, v in self_d921dfa9_4e93_4123_893d_a7e7eb783a32.attr_types().items():
+        # #3: Set all properties to None
+        for (
+            k,
+            v,
+        ) in self_d921dfa9_4e93_4123_893d_a7e7eb783a32.attr_types().items():
             self_d921dfa9_4e93_4123_893d_a7e7eb783a32.set_attribute(k, None)
 
         # Set default values of annotated attributes
-        # for k, v in self.attr_types().items():
-        #     if self.attr_has_default_value(k):
-        #         self.set_default(k)
         self_d921dfa9_4e93_4123_893d_a7e7eb783a32.init()
         self_d921dfa9_4e93_4123_893d_a7e7eb783a32.set_attributes(**kwargs)
 
@@ -116,8 +118,9 @@ class Prodict(dict):
     def get_constructor(self, attr_name, value):
         """
         This method is used for type conversion.
-        Prodict uses this method to get the type of a value, then based on the value, it return a constructor.
-        If the type of a value is 'float' then it returns 'float' since 'float' is also a constructor to build a float
+        Prodict uses this method to get the type of a value, then based on the
+        value, it return a constructor. If the type of a value is 'float' then
+        it returns 'float' since 'float' is also a constructor to build a float
         value.
         """
         attr_type1 = self.attr_type(attr_name)
@@ -151,12 +154,12 @@ class Prodict(dict):
                     constructor = List
                     element_type = attr_type1.__args__[0]
                 elif len(attr_type1.__args__) > 1:
-                    raise TypeError('Only one dimensional List is supported, like List[str], List[int], List[Prodict]')
+                    raise TypeError('Only one dimensional List is supported')
             elif attr_type1.__dict__['__origin__'] is tuple:
                 # if the type is 'Tuple[something]'
                 constructor = tuple
 
-        # print('     constructor={} element_type={}'.format(constructor, element_type))
+        # print('constru={} element_type={}'.format(constructor, element_type))
         return constructor, element_type
 
     def set_attribute(self, attr_name, value):
@@ -168,7 +171,9 @@ class Prodict(dict):
             elif self.attr_type(attr_name) == Any:
                 self[attr_name] = value
             else:
-                constructor, element_type = self.get_constructor(attr_name, value)
+                constructor, element_type = self.get_constructor(
+                    attr_name, value
+                )
                 if constructor is None:
                     self.update({attr_name: value})
                 elif constructor == List:
@@ -200,9 +205,6 @@ class Prodict(dict):
     def set_attributes(self_d921dfa9_4e93_4123_893d_a7e7eb783a32, **d):
         for k, v in d.items():
             self_d921dfa9_4e93_4123_893d_a7e7eb783a32.set_attribute(k, v)
-        """
-        'self' parameter name is changed because of #15: https://github.com/ramazanpolat/prodict/issues/15 
-        """
 
     def __getattr__(self, item):
         return self[item]
@@ -210,10 +212,24 @@ class Prodict(dict):
     def __setattr__(self, name: str, value) -> None:
         self.set_attribute(name, value)
 
-    def to_dict(self, *args, is_recursive=False, exclude_none=False, exclude_none_in_lists=False, **kwargs):
-        ret = {k: _dict_value(v, is_recursive=is_recursive,
-                              exclude_none=exclude_none,
-                              exclude_none_in_lists=exclude_none_in_lists)
-               for k, v in self.items()
-               if _none_condition(v, is_recursive=is_recursive, exclude_none=exclude_none)}
+    def to_dict(
+        self,
+        *args,
+        is_recursive=False,
+        exclude_none=False,
+        exclude_none_in_lists=False,
+        **kwargs
+    ):
+        ret = {
+            k: _dict_value(
+                v,
+                is_recursive=is_recursive,
+                exclude_none=exclude_none,
+                exclude_none_in_lists=exclude_none_in_lists,
+            )
+            for k, v in self.items()
+            if _none_condition(
+                v, is_recursive=is_recursive, exclude_none=exclude_none
+            )
+        }
         return ret

--- a/setup.py
+++ b/setup.py
@@ -6,17 +6,19 @@ setup(
     name='prodict',
     packages=['prodict'],  # this must be the same as the name above
     version=version,
-    description='Prodict = Pro Dictionary with IDE friendly(auto code completion), dot-accessible attributes and more.',
-    long_description='Ever wanted to use a dict like a class and access keys as attributes? '
-                     'Prodict does exactly this.'
-                     'Although there are number of modules doing this, Prodict does a little bit more. You can '
+    description='Prodict = Pro Dictionary with IDE friendly(auto code'
+                'completion), dot-accessible attributes and more.',
+    long_description='Ever wanted to use a dict like a class and access keys'
+                     'as attributes? Prodict does exactly this.'
+                     'Although there are number of modules doing this,'
+                     'Prodict does a little bit more. You can '
                      'provide type hints and get auto-complete!',
     author='Ramazan Polat',
     author_email='ramazanpolat@gmail.com',
     url='https://github.com/ramazanpolat/prodict',
     download_url='https://pypi.python.org/pypi/prodict/' + version,
-    keywords=['prodict', 'python3', 'typehinting', 'dynamic-props', 'dict', 'dictionary', 'auto-complete',
-              'auto-code-complete'],
+    keywords=['prodict', 'python3', 'typehinting', 'dynamic-props', 'dict',
+              'dictionary', 'auto-complete', 'auto-code-complete'],
     classifiers=['Development Status :: 4 - Beta',
                  'Intended Audience :: Developers',
                  'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
               'dictionary', 'auto-complete', 'auto-code-complete'],
     classifiers=['Development Status :: 4 - Beta',
                  'Intended Audience :: Developers',
-                 'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
+                 'License :: OSI Approved :: MIT License',
                  'Programming Language :: Python :: 3.7',
                  'Topic :: Software Development :: Libraries :: Python Modules'],
 )

--- a/test_prodict.py
+++ b/test_prodict.py
@@ -1,8 +1,7 @@
+import contextlib
 import pickle
 from unittest import TestCase
-from typing import List, Any, Tuple
-import unittest
-from datetime import datetime
+from typing import List, Any, Dict, Tuple
 from prodict import Prodict
 import copy
 
@@ -41,14 +40,14 @@ class Computer(Prodict):
     brand: str
     cpu: Cpu
     rams: List[Ram]
-    dict_key: dict
+    dict_key: dict  # type: ignore
     uninitialized: str
     rams2: List[Ram]
 
-    def total_ram(self):
+    def total_ram(self) -> int:  # sourcery skip: comprehension-to-generator
         return sum([ram.capacity for ram in self.rams])
 
-    def total_ram2(self):
+    def total_ram2(self) -> int:  # sourcery skip: comprehension-to-generator
         if 'rams2' in self and self['rams2'] is not None:
             return sum([ram.capacity for ram in self.rams2])
         return 0
@@ -57,7 +56,7 @@ class Computer(Prodict):
 class AnyType(Prodict):
     # x=1 type: Any
     a: Any
-    b: Tuple
+    b: Tuple[Any]
     c: Any
 
 
@@ -74,13 +73,13 @@ class SimpleKeyDefaultValue(Prodict):
 
 
 class AdvancedKeyValue(Prodict):
-    tuple_key: tuple
-    list_key: list
-    dict_key: dict
+    tuple_key: Tuple[Any]
+    list_key: List[Any]
+    dict_key: Dict[Any, Any]
 
 
 class ListProdict(Prodict):
-    li: List
+    li: List[Any]
     li_str: List[str]
     li_int: List[int]
 
@@ -91,7 +90,7 @@ class Recursive(Prodict):
 
 
 class TestProdict(TestCase):
-    def test_deep_recursion_from_dict(self):
+    def test_deep_recursion_from_dict(self) -> None:
         computer_dict = {
             'x_str': 'string',
             'x_int': 0,
@@ -99,37 +98,21 @@ class TestProdict(TestCase):
             'dict_key': {'info': 'This must be a dict'},
             'brand': 'acme',
             'rams': [
-                {
-                    'brand': 'Kingston',
-                    'capacity': 4,
-                    'unit': 'GB'
-                },
-                {
-                    'brand': 'Samsung',
-                    'capacity': 8,
-                    'unit': 'GB'
-
-                }],
+                {'brand': 'Kingston', 'capacity': 4, 'unit': 'GB'},
+                {'brand': 'Samsung', 'capacity': 8, 'unit': 'GB'},
+            ],
             'cpu': {
                 'brand': 'Intel',
                 'model': 'i5-4670',
                 'cache': 3,
                 'cores': [
-                    {
-                        'threads': 2,
-                        'clock': 3.4,
-                        'unit': 'GHz'
-                    },
-                    {
-                        'threads': 4,
-                        'clock': 3.1,
-                        'unit': 'GHz'
-                    }
-                ]
-            }
+                    {'threads': 2, 'clock': 3.4, 'unit': 'GHz'},
+                    {'threads': 4, 'clock': 3.1, 'unit': 'GHz'},
+                ],
+            },
         }
 
-        computer: Computer = Computer.from_dict(computer_dict)
+        computer = Computer.from_dict(computer_dict)
         # print('computer =', computer)
         assert type(computer) == Computer
         # print('type(computer.dict_key) =', type(computer.dict_key))
@@ -148,19 +131,19 @@ class TestProdict(TestCase):
         print("type(computer['rams']) =", type(computer['rams']))
         print("computer['rams'][0] =", computer['rams'][0])
 
-    def test_bracket_access(self):
+    def test_bracket_access(self) -> None:
         pd = SimpleKeyValue()
         pd.str_key = 'str_value_123'
         assert pd['str_key'] == pd.str_key
         assert pd.get('str_key') == pd.str_key
 
-    def test_null_assignment(self):
+    def test_null_assignment(self) -> None:
         pd = SimpleKeyValue()
 
         pd.str_key = 'str1'
         assert pd.str_key == 'str1'
 
-        pd.str_key = None
+        pd.str_key = None  # type: ignore
         assert pd.str_key is None
 
         pd.dynamic_int = 1
@@ -175,7 +158,7 @@ class TestProdict(TestCase):
         pd.dynamic_str = None
         assert pd.dynamic_str is None
 
-    def test_multiple_instances(self):
+    def test_multiple_instances(self) -> None:
         class Multi(Prodict):
             a: int
 
@@ -187,7 +170,7 @@ class TestProdict(TestCase):
 
         assert m2.a == m1.a + 1
 
-    def test_property(self):
+    def test_property(self) -> None:
         class PropertyClass(Prodict):
             first: int
             second: int
@@ -201,12 +184,12 @@ class TestProdict(TestCase):
         pc = PropertyClass(first=first, second=second)
         assert pc.diff == abs(second - first)
 
-    def test_use_defaults_method(self):
+    def test_use_defaults_method(self) -> None:
         class WithDefault(Prodict):
             a: int
             b: str
 
-            def init(self):
+            def init(self) -> None:
                 self.a = 1
                 self.b = 'string'
 
@@ -214,7 +197,7 @@ class TestProdict(TestCase):
         assert wd.a == 1
         assert wd.b == 'string'
 
-    def test_type_conversion(self):
+    def test_type_conversion(self) -> None:
         class TypeConversionClass(Prodict):
             an_int: int
             a_str: str
@@ -226,7 +209,7 @@ class TestProdict(TestCase):
         assert TypeConversionClass(a_float=123.45).a_float == 123.45
         assert TypeConversionClass(a_float='123.45').a_float == 123.45
 
-    def test_deepcopy1(self):
+    def test_deepcopy1(self) -> None:
         root_node = Prodict(number=1, data="ROOT node", next=None)
 
         copied = copy.deepcopy(root_node)
@@ -249,7 +232,7 @@ class TestProdict(TestCase):
         # have same type
         assert type(root_node) is type(copied)
 
-    def test_deepcopy2(self):
+    def test_deepcopy2(self) -> None:
         class MyLinkListNode(Prodict):
             number: int
             data: Any
@@ -280,25 +263,20 @@ class TestProdict(TestCase):
         # have same type
         assert type(root_node) is type(copied)
 
-    def test_unknown_attr(self):
+    def test_unknown_attr(self) -> None:
         ram = Ram.from_dict({'brand': 'Samsung', 'capacity': 4, 'unit': 'YB'})
         print(ram.brand)  # Ok
 
         # Should fail
-        try:
+        with contextlib.suppress(KeyError):
             print(ram['flavor'])
             assert False
-        except KeyError:
-            pass
-
         # Should fail
-        try:
+        with contextlib.suppress(KeyError):
             print(ram.flavor)
             assert False
-        except KeyError:
-            pass
 
-    def test_default_none(self):
+    def test_default_none(self) -> None:  # sourcery skip: raise-specific-error
         class Car(Prodict):
             brand: str
             year: int
@@ -307,12 +285,14 @@ class TestProdict(TestCase):
         print('honda.year:', honda.year)
         assert honda.year is None
         try:
-            print(honda.color)  # This also raises KeyError since it is not even defined or set.
+            print(
+                honda.color
+            )  # This also raises KeyError since it is not even defined or set.
             raise Exception("'honda.color' must raise KeyError")
         except KeyError:
             print("'honda.color' raises KeyError. Ok")
 
-    def test_to_dict_recursive(self):
+    def test_to_dict_recursive(self) -> None:
         dad = Dad(name='Bob')
         son = Son(name='Jeremy', father=dad)
 
@@ -326,7 +306,7 @@ class TestProdict(TestCase):
         # print(type(son.to_dict(is_recursive=True)['father']))
         assert type(son.to_dict(is_recursive=True)['father']) == dict
 
-    def test_to_dict_exclude_none(self):
+    def test_to_dict_exclude_none(self) -> None:
         dad = Dad(name='Bob')
         son = Son(name='Jeremy', father=dad)
 
@@ -334,17 +314,26 @@ class TestProdict(TestCase):
         assert 'age' not in son.to_dict(exclude_none=True)
 
         assert 'age' in son.to_dict()['father']
-        assert 'age' not in son.to_dict(is_recursive=True, exclude_none=True)['father']
+        assert (
+            'age'
+            not in son.to_dict(is_recursive=True, exclude_none=True)['father']
+        )
 
         print('exclude_none=False:', son.to_dict(exclude_none=False))
         print('exclude_none=True:', son.to_dict(exclude_none=True))
 
-        print('exclude_none=False:', son.to_dict(exclude_none=False, is_recursive=True))
-        print('exclude_none=True:', son.to_dict(exclude_none=True, is_recursive=True))
+        print(
+            'exclude_none=False:',
+            son.to_dict(exclude_none=False, is_recursive=True),
+        )
+        print(
+            'exclude_none=True:',
+            son.to_dict(exclude_none=True, is_recursive=True),
+        )
 
         print(type(son.to_dict()['father'].to_dict()))
 
-    def test_to_dict_exclude_none_for_list_elements(self):
+    def test_to_dict_exclude_none_for_list_elements(self) -> None:
         class MyEntry(Prodict):
             some_str: str
             some_dict: Prodict
@@ -359,17 +348,17 @@ class TestProdict(TestCase):
                     "some_str": "Hello",
                     "some_dict": {
                         "name": "Frodo",
-                    }
+                    },
                 },
-                {
-                    "some_str": "World"
-                }
+                {"some_str": "World"},
             ],
-            "my_var": None
+            "my_var": None,
         }
 
         model = ModelConfig.from_dict(data)
-        d1 = model.to_dict(exclude_none=True, is_recursive=False, exclude_none_in_lists=True)
+        d1 = model.to_dict(
+            exclude_none=True, is_recursive=False, exclude_none_in_lists=True
+        )
         print(d1)
         assert 'my_var' not in d1
         assert 'some_dict' not in d1['my_list'][1]
@@ -386,11 +375,7 @@ class TestProdict(TestCase):
         assert 'my_var' in d2
         assert 'some_dict' not in d2['my_list'][1]
 
-
-
-
-
-    def test_issue12(self):
+    def test_issue12(self) -> None:
         class Comment(Prodict):
             user_id: int
             comment: str
@@ -419,14 +404,14 @@ class TestProdict(TestCase):
                         {
                             "user_id": 2,
                             "comment": "Good to see you blogging",
-                            "date": "2018-01-02 03:04:06"
+                            "date": "2018-01-02 03:04:06",
                         },
                         {
                             "user_id": 3,
                             "comment": "Good for you",
-                            "date": "2018-01-02 03:04:07"
-                        }
-                    ]
+                            "date": "2018-01-02 03:04:07",
+                        },
+                    ],
                 },
                 {
                     "title": "Hello World 2",
@@ -436,49 +421,50 @@ class TestProdict(TestCase):
                         {
                             "user_id": 2,
                             "comment": "Good to see you blogging",
-                            "date": "2018-01-02 03:04:06"
+                            "date": "2018-01-02 03:04:06",
                         },
                         {
                             "user_id": 3,
                             "comment": "Good for you",
-                            "date": "2018-01-02 03:04:07"
-                        }
-                    ]
-                }
-            ]
+                            "date": "2018-01-02 03:04:07",
+                        },
+                    ],
+                },
+            ],
         }
 
         p = User.from_dict(json1)
         assert len(p.posts) == 2
         assert type(p.posts[0].title) == str
 
-    def test_issue15(self):
+    def test_issue15(self) -> None:
         """url: https://github.com/ramazanpolat/prodict/issues/15
         if the payload has a attribute named 'self' then we get a TypeError:
             TypeError: __init__() got multiple values for argument 'self'
 
         """
         try:
-            p = Prodict(self=1)
+            Prodict(self=1)
             assert True
         except TypeError:
             assert False
 
-    def test_accept_generator(self):
+    def test_accept_generator(self) -> None:
         """
         https://github.com/ramazanpolat/prodict/issues/18
         """
         s = ';O2Sat:92;HR:62;RR:0'
 
         # this works
-        dd1 = dict(x.split(':') for x in s.split(';') if ':' in x)
+        # dd1 = dict(x.split(':') for x in s.split(';') if ':' in x)
 
-        # this fails with TypeError: __init__() takes 1 positional argument but 2 were given
+        # this fails with
+        # TypeError: __init__() takes 1 positional argument but 2 were given
         pd1 = Prodict(x.split(':') for x in s.split(';') if ':' in x)
         print(pd1)
         assert True
 
-    def test_pickle(self):
+    def test_pickle(self) -> None:
         try:
             encoded = pickle.dumps(Prodict(a=42))
             decoded = pickle.loads(encoded)
@@ -488,5 +474,5 @@ class TestProdict(TestCase):
             # print(encoded)
             # decoded = pickle.loads(encoded)
             # print(decoded)
-        except:
+        except Exception:
             assert False

--- a/test_prodict.py
+++ b/test_prodict.py
@@ -89,6 +89,27 @@ class Recursive(Prodict):
 
 
 class TestProdict(TestCase):
+    def test_item_name_dash_mapping(self) -> None:
+        """Test custom item map for dashes to underscores and leading digits"""
+
+        class ProdictWithDashItemMapping(Prodict):
+            def item_name_for_attribute(self, attribute_name: str) -> str:
+                if attribute_name[0] == "_":
+                    attribute_name = attribute_name[1:]
+                return attribute_name.replace("_", "-")
+
+        class NetworkConnection(ProdictWithDashItemMapping):
+            interface_name: str
+            _802_11_wireless_ssid: str
+
+        networkconnection_dict = {
+            "interface-name": "wlan0",
+            "802-11-wireless-ssid": "cloud9",
+        }
+        networkconnection = NetworkConnection.from_dict(networkconnection_dict)
+        assert networkconnection.interface_name == "wlan0"
+        assert networkconnection._802_11_wireless_ssid == "cloud9"
+
     def test_deep_recursion_from_dict(self) -> None:
         computer_dict = {
             'x_str': 'string',

--- a/test_prodict.py
+++ b/test_prodict.py
@@ -1,7 +1,7 @@
 import contextlib
 import pickle
 from unittest import TestCase
-from typing import List, Any, Dict, Tuple
+from typing import List, Any, Dict, Tuple, Optional
 from prodict import Prodict
 import copy
 
@@ -61,7 +61,7 @@ class AnyType(Prodict):
 
 class SimpleKeyValue(Prodict):
     int_key: int
-    str_key: str
+    str_key: Optional[str]  # #8: For mypy: It shall know that = None is fine
     float_key: float
 
 
@@ -152,7 +152,7 @@ class TestProdict(TestCase):
         pd.str_key = 'str1'
         assert pd.str_key == 'str1'
 
-        pd.str_key = None  # type: ignore
+        pd.str_key = None
         assert pd.str_key is None
 
         pd.dynamic_int = 1

--- a/test_prodict.py
+++ b/test_prodict.py
@@ -54,7 +54,6 @@ class Computer(Prodict):
 
 
 class AnyType(Prodict):
-    # x=1 type: Any
     a: Any
     b: Tuple[Any]
     c: Any
@@ -113,23 +112,12 @@ class TestProdict(TestCase):
         }
 
         computer = Computer.from_dict(computer_dict)
-        # print('computer =', computer)
         assert type(computer) == Computer
-        # print('type(computer.dict_key) =', type(computer.dict_key))
         assert type(computer.dict_key) == Prodict
-        # print('computer.brand =', computer.brand)
         assert type(computer.brand) == str
-        # print('computer.cpu =', computer.cpu)
         assert type(computer.cpu) == Cpu
-        # print('type(computer.rams) =', type(computer.rams))
         assert type(computer.rams) == list
-        # print('computer.rams[0] =', computer.rams[0])
         assert type(computer.rams[0]) == Ram
-        print('Total ram =', computer.total_ram())
-        print('Total ram2 =', computer.total_ram2())
-        print("computer['rams'] =", computer['rams'])
-        print("type(computer['rams']) =", type(computer['rams']))
-        print("computer['rams'][0] =", computer['rams'][0])
 
     def test_bracket_access(self) -> None:
         pd = SimpleKeyValue()
@@ -211,19 +199,7 @@ class TestProdict(TestCase):
 
     def test_deepcopy1(self) -> None:
         root_node = Prodict(number=1, data="ROOT node", next=None)
-
         copied = copy.deepcopy(root_node)
-
-        print("--root-node id:", id(root_node))
-        print(root_node)
-        print("--copied id:", id(copied))
-        print(copied)
-        print("--root_node.data")
-        print(type(root_node))
-        print(root_node.data)
-        print("--copied.data")
-        print(type(copied))
-        print(copied.data)
 
         # have same dict
         assert copied == root_node
@@ -239,22 +215,7 @@ class TestProdict(TestCase):
             next: Prodict
 
         root_node = MyLinkListNode(number=1, data="ROOT node", next=None)
-        # node1 = MyLinkListNode(number=2, data="1st node", next=None)
-        # root_node.next = node1
-
         copied = copy.deepcopy(root_node)
-        # copied.number += 1
-
-        print("--root-node id:", id(root_node))
-        print(root_node)
-        print("--copied id:", id(copied))
-        print(copied)
-        print("--root_node.data")
-        print(type(root_node))
-        print(root_node.data)
-        print("--copied.data")
-        print(type(copied))
-        print(copied.data)
 
         # have same dict
         assert copied == root_node
@@ -295,15 +256,7 @@ class TestProdict(TestCase):
     def test_to_dict_recursive(self) -> None:
         dad = Dad(name='Bob')
         son = Son(name='Jeremy', father=dad)
-
-        # print('dad dict:', dad.to_dict())
-        # print('--')
-        # print('son dict:', son.to_dict())
-        # print('--')
-
-        # print(type(son.to_dict(is_recursive=False)['father']))
         assert type(son.to_dict(is_recursive=False)['father']) == Dad
-        # print(type(son.to_dict(is_recursive=True)['father']))
         assert type(son.to_dict(is_recursive=True)['father']) == dict
 
     def test_to_dict_exclude_none(self) -> None:
@@ -318,20 +271,6 @@ class TestProdict(TestCase):
             'age'
             not in son.to_dict(is_recursive=True, exclude_none=True)['father']
         )
-
-        print('exclude_none=False:', son.to_dict(exclude_none=False))
-        print('exclude_none=True:', son.to_dict(exclude_none=True))
-
-        print(
-            'exclude_none=False:',
-            son.to_dict(exclude_none=False, is_recursive=True),
-        )
-        print(
-            'exclude_none=True:',
-            son.to_dict(exclude_none=True, is_recursive=True),
-        )
-
-        print(type(son.to_dict()['father'].to_dict()))
 
     def test_to_dict_exclude_none_for_list_elements(self) -> None:
         class MyEntry(Prodict):
@@ -359,19 +298,14 @@ class TestProdict(TestCase):
         d1 = model.to_dict(
             exclude_none=True, is_recursive=False, exclude_none_in_lists=True
         )
-        print(d1)
         assert 'my_var' not in d1
         assert 'some_dict' not in d1['my_list'][1]
 
         d2 = model.to_dict(exclude_none=True, exclude_none_in_lists=False)
-
-        print(d2)
         assert 'my_var' not in d2
         assert 'some_dict' in d2['my_list'][1]
 
         d2 = model.to_dict(exclude_none_in_lists=True)
-
-        print(d2)
         assert 'my_var' in d2
         assert 'some_dict' not in d2['my_list'][1]
 
@@ -469,10 +403,5 @@ class TestProdict(TestCase):
             encoded = pickle.dumps(Prodict(a=42))
             decoded = pickle.loads(encoded)
             assert decoded.a == 42
-            # p = Prodict(a=1, b=2)
-            # encoded = pickle.dumps(p)
-            # print(encoded)
-            # decoded = pickle.loads(encoded)
-            # print(decoded)
         except Exception:
             assert False


### PR DESCRIPTION
test_prodict.py: Fix mypy warning for Optional string (see #8)


Based on Commit #34 (included it's included commits) and #32.

When merging #34 (and it's included commits, starting from #28) without creating a merge commit (using github's rebase and apply method), this will apply cleanly.