### PR TITLE
Comment mistake in README.MD on line 325

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -322,7 +322,7 @@ class MyDataWithDefaults(Prodict):
 
 data = MyDataWithDefaults(dynamic=43)
 print(data)
-# {'an_int':43, 'a_str':'string', 'dynamic':43}
+# {'an_int':42, 'a_str':'string', 'dynamic':43}
 
 ``` 
 


### PR DESCRIPTION
The comment in the readme says the output should be 
```
# {'an_int':43, 'a_str':'string', 'dynamic':43}
``` 

but it should be
```
# {'an_int':42, 'a_str':'string', 'dynamic':43}
``` 

Code tested locally
![image](https://user-images.githubusercontent.com/24842210/184865028-edcc6d45-8dfb-44e5-a22b-381d961e8226.png)
